### PR TITLE
install alsa-utils (needed for buster lite)

### DIFF
--- a/installation/install-jukebox.sh
+++ b/installation/install-jukebox.sh
@@ -110,7 +110,7 @@ install_jukebox_dependencies() {
     samba samba-common-bin \
     python3 python3-dev python3-pip python3-setuptools python3-mutagen python3-gpiozero \
     ffmpeg \
-    alsa-tools \
+    alsa-utils \
     --no-install-recommends \
     --allow-downgrades \
     --allow-remove-essential \


### PR DESCRIPTION
#1255 misses the alsa-utils package that is needed make it work on buster-lite
see #1467